### PR TITLE
Improve documentation colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Willow Documentation
+
+Source code for the [heywillow.io](https://heywillow.io/) website.
+
+## Running the docs locally
+
+```shell
+python -m venv venv
+source ./venv/bin/activate
+pip install -r requirements.txt
+./utils.sh dev
+```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,15 @@
+/*
+    https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/
+    https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/_colors.scss
+*/
+
 :root {
     --md-primary-fg-color:        #583759;
     /* --md-primary-fg-color--light: #FBE870;
     --md-primary-fg-color--dark:  #583759; */
-  }
+}
+
+.md-typeset a {
+    /* Use a brighter purple for links in the documentation text */
+    color:                        #9D00A2;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ theme:
   icon:
     admonition:
       tip: material/shopping-outline  
-  logo: images/logo-purple.svg
+  logo: images/logo-yellow.svg
 
 plugins:
   - search


### PR DESCRIPTION
I think the links in the documentation are too dark to distinguish from the rest of the text, so this PR makes them a brighter purple.

I've also fixed the color of the logo in the header, and added instructions to the README for running the documentation server locally.

Before:
![Screenshot from 2023-09-29 19-11-10](https://github.com/toverainc/willow-docs/assets/79419/5faf97e3-abfb-4ebf-83a9-fd66e87d7172)

After:
![Screenshot from 2023-09-29 19-11-15](https://github.com/toverainc/willow-docs/assets/79419/9f80e155-d8e7-408a-9f44-acb764d2a0e2)